### PR TITLE
Check tzoffset for every line. Use POSIX::strftime::GNU if available.

### DIFF
--- a/lib/Apache/LogFormat/Compiler.pm
+++ b/lib/Apache/LogFormat/Compiler.pm
@@ -39,7 +39,7 @@ BEGIN {
 
 sub _strftime {
     my ($fmt, @time) = @_;
-    if (_has_strftime_z) {
+    if (not _has_strftime_z) {
         my $tz = _tzoffset(@time);
         $fmt =~ s/%z/$tz/g;
     }


### PR DESCRIPTION
Apache::LogFormat::Compiler has a problem. Twice a year the timezone is changed because of daylight saving. A::LF::C ignores this fact and still shows old timezone after change.

You can use POSIX::strftime::GNU which supports all GNU extenstions for strftime() function. It is good choise because Windows and old Unices have limited strftime's formatting. If you want to leave POSIX::strtime::GNU optional there can be fallback to own function which calculates tzoffset by its own.

Unfortunately this solution has some performance penalty but still there is a difference between log and compilelog:

```
compilelog:  3 wallclock secs ( 2.70 usr +  0.54 sys =  3.24 CPU) @ 15372.53/s (n=49807)
       log:  4 wallclock secs ( 2.83 usr +  0.32 sys =  3.15 CPU) @ 11200.00/s (n=35280)
              Rate        log compilelog
```
