### PR TITLE
POSIX::tzset not implemented on Windows

### DIFF
--- a/t/04_tz.t
+++ b/t/04_tz.t
@@ -7,6 +7,7 @@ use Test::MockTime qw/set_fixed_time restore_time/;
 use t::Req2PSGI;
 use Apache::LogFormat::Compiler;
 use HTTP::Request::Common;
+use Try::Tiny;
 
 my @abbr = qw( Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec );
 my @timezones = ( 
@@ -16,6 +17,8 @@ my @timezones = (
     ['Europe/London', '+0000','+0100','+0100','+0000'],
     ['America/New_York','-0500', '-0400', '-0400', '-0500']
 );
+
+try { POSIX::tzset } catch { plan skip_all => 'POSIX::tzset not implemented on this architecture' };
 
 for my $timezones (@timezones) {
     my ($timezone, @tz) = @$timezones;


### PR DESCRIPTION
Windows has limited POSIX support. I.e. POSIX::tzset is not implemented. Even that, you can change the timezone only once on one subprocess.

I suggest to disable TZ tests if POSIX::tzset fails.

There is possibility to make these tests working on Windows. You can check https://github.com/dex4er/perl-POSIX-strftime-GNU/blob/master/t/120_tmzone.t but it is really weird and you need to use some Windows' quirks.

BTW, there is still risk that particular timezone is not implemented on the system. You can detect if it really works as you can see in my example and skip the test in such case. As far as I remember, some Solarises doesn't prove the whole set of timezone data.

Another solution to consider: just skip all tz tests unless ran on Linux :)
