### PR TITLE
requires perl v5.8.4

### DIFF
--- a/META.json
+++ b/META.json
@@ -45,7 +45,7 @@
          "requires" : {
             "POSIX" : "0",
             "Time::Local" : "0",
-            "perl" : "5.008005"
+            "perl" : "5.008004"
          },
          "suggests" : {
             "POSIX::strftime::GNU" : "0"

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires 'POSIX';
 requires 'Time::Local';
-requires 'perl', '5.008005';
+requires 'perl', '5.008004';
 
 suggests 'POSIX::strftime::GNU';
 

--- a/lib/Apache/LogFormat/Compiler.pm
+++ b/lib/Apache/LogFormat/Compiler.pm
@@ -2,7 +2,7 @@ package Apache::LogFormat::Compiler;
 
 use strict;
 use warnings;
-use 5.008005;
+use 5.008004;
 use Carp;
 use POSIX ();
 use Time::Local qw//;


### PR DESCRIPTION
Hi,

Whould you mind to lower requirements for Perl to version 5.8.4?

This is the default version for Solaris 10:

$ perl -v

This is perl, v5.8.4 built for i86pc-solaris-64int
(with 37 registered patches, see perl -V for more detail)

I see that your module and Plack work well with this version of Perl.

Thanks
