### PR TITLE
POSIX::setlocale fails on system without locales (Android)

### DIFF
--- a/lib/Apache/LogFormat/Compiler.pm
+++ b/lib/Apache/LogFormat/Compiler.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use 5.008005;
 use Carp;
+use Config;
 use POSIX ();
 use Time::Local qw//;
 
@@ -52,10 +53,15 @@ sub _strftime {
         my $tz = _tzoffset($self,@time);
         $fmt =~ s/%z/$tz/g;
     }
-    my $old_locale = eval { POSIX::setlocale(&POSIX::LC_ALL) };
-    eval { POSIX::setlocale(&POSIX::LC_ALL, 'C') };
+    my $old_locale;
+    if ( $Config{d_setlocale} ) {
+        $old_locale = POSIX::setlocale(&POSIX::LC_ALL);
+        POSIX::setlocale(&POSIX::LC_ALL, 'C');
+    }
     my $out = _posix_strftime($fmt, @time);
-    eval { POSIX::setlocale(&POSIX::LC_ALL, $old_locale) };
+    if ( $Config{d_setlocale} ) {
+        POSIX::setlocale(&POSIX::LC_ALL, $old_locale);
+    }
     return $out;
 };
 


### PR DESCRIPTION
I'm trying to install Apache::LogFormat::Compiler on Android. This system has poor support for locales, so the Perl is usually compiled with -Ui_locale flag.

Error:

```
t/00_compile.t .. ok   
t/01_basic.t .... ok   
t/02_custom.t ... 1/? Your vendor has not defined POSIX macro LC_ALL, used at /storage/sdcard0/home/.cpanm/work/1389471612.8629/Apache-LogFormat-Compiler-0.22/blib/lib/Apache/LogFormat/Compiler.pm line 55
# Tests were run but no plan was declared and done_testing() was not seen.
t/02_custom.t ... Dubious, test returned 255 (wstat 65280, 0xff00)
All 1 subtests passed 
t/03_extra.t .... ok   
t/04_tz.t ....... 1/? Your vendor has not defined POSIX macro LC_ALL, used at /storage/sdcard0/home/.cpanm/work/1389471612.8629/Apache-LogFormat-Compiler-0.22/blib/lib/Apache/LogFormat/Compiler.pm line 55
    # Child (Australia/Darwin custom format) exited without calling finalize()

#   Failed test 'Australia/Darwin custom format'
#   at /data/perl/lib/5.18.2/Test/Builder.pm line 252.
# Tests were run but no plan was declared and done_testing() was not seen.
t/04_tz.t ....... Dubious, test returned 29 (wstat 7424, 0x1d00)
Failed 1/2 subtests 
```

After this patch the module installs cleanly.
