### PR TITLE
Lower Perl version requirements to 5.8.1

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires 'POSIX';
 requires 'Time::Local';
-requires 'perl', '5.008004';
+requires 'perl', '5.008001';
 requires 'POSIX::strftime::Compiler', '0.30';
 
 on test => sub {

--- a/lib/Apache/LogFormat/Compiler.pm
+++ b/lib/Apache/LogFormat/Compiler.pm
@@ -2,7 +2,7 @@ package Apache::LogFormat::Compiler;
 
 use strict;
 use warnings;
-use 5.008004;
+use 5.008001;
 use Carp;
 use POSIX::strftime::Compiler qw//;
 use constant {


### PR DESCRIPTION
Please lower Perl version requirements to 5.8.1.

I would like to run Plack application on such ancient Perl version and this requirement won't allow me to use AccessLog middleware.

I ran this module with Perl 5.8.1 and it worked without problems.

Thank you.
