### PR TITLE
Make `%T` to formatted in seconds.

### DIFF
--- a/lib/Apache/LogFormat/Compiler.pm
+++ b/lib/Apache/LogFormat/Compiler.pm
@@ -84,7 +84,7 @@ our %char_handler = (
                        " " . $_[ENVS]->{SERVER_PROTOCOL}!,
     s => q!$_[RES]->[0]!,
     b => q!(defined $_[LENGTH] ? $_[LENGTH] : '-')!,
-    T => q!(defined $_[REQTIME] ? int($_[REQTIME]*1_000_000) : '-')!,
+    T => q!(defined $_[REQTIME] ? int($_[REQTIME]/1_000_000) : '-')!,
     D => q!(defined $_[REQTIME] ? $_[REQTIME] : '-')!,
     v => q!($_[ENVS]->{SERVER_NAME} || '-')!,
     V => q!($_[ENVS]->{HTTP_HOST} || $_[ENVS]->{SERVER_NAME} || '-')!,

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -34,7 +34,7 @@ use Apache::LogFormat::Compiler;
 
 {
     my $log_handler = Apache::LogFormat::Compiler->new(
-        '%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i" %D'
+        '%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i" %D %T'
     );
     ok($log_handler);
     my $log = $log_handler->log_line(
@@ -45,7 +45,7 @@ use Apache::LogFormat::Compiler;
         time()
     );
     like $log, 
-        qr!^[a-z0-9\.]+ - - \[\d{2}/\w{3}/\d{4}:\d{2}:\d{2}:\d{2} [+\-]\d{4}\] "GET / HTTP/1\.1" 200 2 "-" "-" 1000000$!;
+        qr!^[a-z0-9\.]+ - - \[\d{2}/\w{3}/\d{4}:\d{2}:\d{2}:\d{2} [+\-]\d{4}\] "GET / HTTP/1\.1" 200 2 "-" "-" 1000000 1$!;
 };
 
 


### PR DESCRIPTION
refs: https://github.com/plack/Plack/issues/549

When `$reqtime` (in microseconds) is passed to log_line, `%T` shoule be formatted to `int($reqtime/1_000_000)`, but with current implementation it's formatted to `int($reqtime*1_000_000)`.
