### PR TITLE
Log the real IP if running as a proxy.

### DIFF
--- a/lib/Apache/LogFormat/Compiler.pm
+++ b/lib/Apache/LogFormat/Compiler.pm
@@ -76,7 +76,7 @@ my $block_handler = sub {
 
 our %char_handler = (
     '%' => q!'%'!,
-    h => q!($_[ENVS]->{REMOTE_ADDR} || '-')!,
+    h => q!($_[ENVS]->{REMOTE_ADDR} || $_[ENVS]->{HTTP_X_REAL_IP} || '-')!,
     l => q!'-'!,
     u => q!($_[ENVS]->{REMOTE_USER} || '-')!,
     t => q!'[' . $t . ']'!,


### PR DESCRIPTION
It is a typical case to run Starman as a proxy under Nginx. If the Starman is run from plackup, the log does not show anything for the remote addr (REMOTE_ADDR is empty). This then prints HTTP_X_REAL_IP instead. It is there since typically one sets in such situation proxy_set_header X-Real-IP $remote_addr in Nginx location block.
